### PR TITLE
fix: bugs in error wrapping and ecdsa key handling

### DIFF
--- a/core/client/evm/eth.go
+++ b/core/client/evm/eth.go
@@ -580,23 +580,23 @@ type metadata interface {
 	GetAbi() (*abi.ABI, error)
 }
 
-func (e *Client) formatEVMContractError(meta metadata, err error) error {
+func (e *Client) formatEVMContractError(meta metadata, originalErr error) error {
 	type jsonError interface {
 		Error() string
 		ErrorData() interface{}
 		ErrorCode() int
 	}
 	var errData jsonError
-	if !errors.As(err, &errData) {
-		return err
+	if !errors.As(originalErr, &errData) {
+		return originalErr
 	}
 	if errData.ErrorCode() != 3 && errData.ErrorData() == nil {
-		return err
+		return originalErr
 	}
 
 	matches := customErrRegExp.FindStringSubmatch(errData.Error())
 	if len(matches) < 1 {
-		return err
+		return originalErr
 	}
 
 	parsedAbi, err := meta.GetAbi()
@@ -618,7 +618,7 @@ func (e *Client) formatEVMContractError(meta metadata, err error) error {
 		return err
 	}
 
-	return errors.Errorf("%w: %s", err, contractError.String())
+	return errors.Errorf("%w: %s", originalErr, contractError.String())
 }
 
 func (e *Client) formatEVMError(err error) error {

--- a/core/usecase/crypto/ecdsaSecp256k1/key.go
+++ b/core/usecase/crypto/ecdsaSecp256k1/key.go
@@ -37,7 +37,11 @@ func Hash(msg []byte) MessageHash {
 }
 
 func NewPrivateKey(b []byte) (*PrivateKey, error) {
-	fixedLengthBytes := big.NewInt(0).SetBytes(b).FillBytes(make([]byte, 32))
+	kInt := big.NewInt(0).SetBytes(b)
+	if kInt.BitLen() > 32*8 { // 32 bytes = 256 bits
+		return nil, errors.Errorf("ecdsaSecp256k1: private key too long, expected 32 bytes, got %d bytes", len(b))
+	}
+	fixedLengthBytes := kInt.FillBytes(make([]byte, 32))
 
 	k, err := crypto.ToECDSA(fixedLengthBytes)
 	if err != nil {


### PR DESCRIPTION
This PR:

1. Fixes bug in evm error wrapping, we were overwriting the original `err` var leading to errors like this `failed to call getCurrentEpoch: %!w(<nil>): error EpochManager_NoCheckpoint()` showing up where err=nil

2. fix ecdsa key handling, as we moved to accepting hex formatted keys if user enters wrong key >32 bytes we were panicing with `panic: math/big: buffer too small to fit value`, added check to ensure length. 