### PR TITLE
fix: do not commit duplicate header

### DIFF
--- a/internal/usecase/valset-generator/valset_generator_uc.go
+++ b/internal/usecase/valset-generator/valset_generator_uc.go
@@ -43,6 +43,7 @@ type repo interface {
 	GetSignatureRequest(ctx context.Context, reqHash common.Hash) (entity.SignatureRequest, error)
 	SavePendingValidatorSet(ctx context.Context, reqHash common.Hash, valset entity.ValidatorSet) error
 	GetPendingValidatorSet(ctx context.Context, reqHash common.Hash) (entity.ValidatorSet, error)
+	SaveAggregationProof(ctx context.Context, reqHash common.Hash, ap entity.AggregationProof) error
 }
 
 type deriver interface {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Save aggregation proof to prevent data loss

- Check if valset header already committed before duplicate submission

- Add repository method for aggregation proof persistence

- Improve logging level for successful commitments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Aggregation Proof"] --> B["Save to Repository"]
  B --> C["Check Header Committed"]
  C --> D["Skip if Already Committed"]
  C --> E["Commit if Not Committed"]
  E --> F["Log Success"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>valset_generator_handle_agg_proof.go</strong><dd><code>Add proof saving and duplicate commit prevention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/valset-generator/valset_generator_handle_agg_proof.go

<ul><li>Add aggregation proof saving with duplicate check<br> <li> Implement header commitment status verification before committing<br> <li> Change debug log to info log for successful commitments<br> <li> Add TODO comment for future transaction check improvement</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/145/files#diff-9e63149fdf33288bbe2481cb959017b16ab7c5fa2b8006a6b1d6031696a1af48">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>valset_generator_uc.go</strong><dd><code>Extend repository interface for aggregation proof storage</code></dd></summary>
<hr>

internal/usecase/valset-generator/valset_generator_uc.go

- Add `SaveAggregationProof` method to repository interface


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/145/files#diff-2bf2060bf29b24fb4e5d3d391ace5487ee56009d3f9aaa5917fd990cf3807f67">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

