### PR TITLE
feat: handle actions specific to key type

### DIFF
--- a/core/entity/entity.go
+++ b/core/entity/entity.go
@@ -562,6 +562,8 @@ const (
 	SignatureStatStageAggQuorumReached    = "AggQuorumReached"
 	SignatureStatStageAggCompleted        = "AggCompleted"
 	SignatureStatStageAggProofReceived    = "AggProofReceived"
+
+	SignatureStatStageAggregationSkipped = "AggSkipped"
 )
 
 type SignatureStat struct {

--- a/core/entity/key_tag_entity.go
+++ b/core/entity/key_tag_entity.go
@@ -71,6 +71,28 @@ func (kt KeyType) String() (string, error) {
 	return "", errors.New("invalid key type")
 }
 
+// SignerKey returns true if the key type can be used for signing
+func (kt KeyType) SignerKey() bool {
+	switch kt {
+	case KeyTypeBlsBn254, KeyTypeEcdsaSecp256k1:
+		return true
+	case KeyTypeInvalid:
+		return false
+	}
+	return false
+}
+
+// AggregationKey returns true if the key type can be used for aggregation
+func (kt KeyType) AggregationKey() bool {
+	switch kt {
+	case KeyTypeBlsBn254:
+		return true
+	case KeyTypeEcdsaSecp256k1, KeyTypeInvalid:
+		return false
+	}
+	return false
+}
+
 func KeyTypeFromString(typeStr string) (KeyType, error) {
 	switch typeStr {
 	case BLS_BN254_TYPE:

--- a/internal/usecase/aggregator-app/aggregator_app.go
+++ b/internal/usecase/aggregator-app/aggregator_app.go
@@ -84,6 +84,14 @@ func (s *AggregatorApp) HandleSignatureGeneratedMessage(ctx context.Context, msg
 		)
 	}
 
+	if !msg.KeyTag.Type().AggregationKey() {
+		// ignore signature aggregation steps as this key cannot be aggregated
+		if _, err := s.cfg.Repo.UpdateSignatureStat(ctx, msg.RequestHash, entity.SignatureStatStageAggregationSkipped, time.Now()); err != nil {
+			slog.WarnContext(ctx, "Failed to update signature stat: %s", "error", err)
+		}
+		return nil
+	}
+
 	// Get validator set for quorum threshold checks
 	// todo load only valset header when totalVotingPower is added to it
 	validatorSet, err := s.cfg.Repo.GetValidatorSetByEpoch(ctx, uint64(msg.Epoch))

--- a/internal/usecase/signer-app/signer_app.go
+++ b/internal/usecase/signer-app/signer_app.go
@@ -91,6 +91,10 @@ func (s *SignerApp) Sign(ctx context.Context, req entity.SignatureRequest) error
 	ctx = log.WithComponent(ctx, "signer")
 	timeAppSignStart := time.Now()
 
+	if !req.KeyTag.Type().SignerKey() {
+		return errors.Errorf("key tag %s is not a signing key", req.KeyTag)
+	}
+
 	_, err := s.cfg.Repo.GetSignatureRequest(ctx, req.Hash())
 	if err != nil && !errors.Is(err, entity.ErrEntityNotFound) {
 		return errors.Errorf("failed to get signature request: %w", err)


### PR DESCRIPTION
### **User description**
Some key types have limitations like some cannot sign while others cannot aggregate. This PR introduces handling logic according to the expected capabilities.


___

### **PR Type**
Enhancement


___

### **Description**
- Add key type capability validation for signing and aggregation

- Implement `SignerKey()` and `AggregationKey()` methods for `KeyType`

- Skip aggregation for non-aggregatable keys with new status

- Validate signing capability before processing signature requests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["KeyType"] --> B["SignerKey() method"]
  A --> C["AggregationKey() method"]
  B --> D["Signer validation"]
  C --> E["Aggregator validation"]
  E --> F["AggregationSkipped status"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entity.go</strong><dd><code>Add aggregation skipped status constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/entity/entity.go

<ul><li>Add new <code>SignatureStatStageAggregationSkipped</code> constant for tracking <br>skipped aggregation</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/152/files#diff-c76f58ee92ae2683d15cba8895a561ca38c5ea42e937e4d819ec38a73d2df3d2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>key_tag_entity.go</strong><dd><code>Implement key type capability methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/entity/key_tag_entity.go

<ul><li>Add <code>SignerKey()</code> method to check if key type supports signing<br> <li> Add <code>AggregationKey()</code> method to check if key type supports aggregation<br> <li> BLS keys support both signing and aggregation, ECDSA only supports <br>signing</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/152/files#diff-52d2dd3b280aab14393907f546ea33310ec1dafcc8f44e2d2660937c720d9db1">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>aggregator_app.go</strong><dd><code>Add aggregation capability validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/aggregator-app/aggregator_app.go

<ul><li>Check if key type supports aggregation before processing<br> <li> Skip aggregation and update status for non-aggregatable keys<br> <li> Return early for keys that cannot be aggregated</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/152/files#diff-46cf96da1f87c1ed42ba9aeb106f594d2ccfd9f7b782622337709ca9bcf61d37">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>signer_app.go</strong><dd><code>Add signing capability validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/signer-app/signer_app.go

<ul><li>Validate key type supports signing before processing signature request<br> <li> Return error for non-signing key types</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/152/files#diff-0544b8fb7016065ff2de8522f81490696d1e5b79cd86efa32d652a7b865bff41">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

