### PR TITLE
fix: ensure scheduler info always available

### DIFF
--- a/core/usecase/valset-deriver/valset_deriver.go
+++ b/core/usecase/valset-deriver/valset_deriver.go
@@ -129,7 +129,7 @@ func (v *Deriver) GetValidatorSet(ctx context.Context, epoch uint64, config enti
 		Status:           entity.HeaderDerived,
 	}
 
-	aggIndices, commIndices, err := v.GetSchedulerInfo(ctx, valset, config)
+	aggIndices, commIndices, err := GetSchedulerInfo(ctx, valset, config)
 	if err != nil {
 		return entity.ValidatorSet{}, errors.Errorf("failed to get scheduler info: %w", err)
 	}
@@ -139,7 +139,7 @@ func (v *Deriver) GetValidatorSet(ctx context.Context, epoch uint64, config enti
 	return valset, nil
 }
 
-func (v *Deriver) GetSchedulerInfo(ctx context.Context, valset entity.ValidatorSet, config entity.NetworkConfig) (aggIndices []uint32, commIndices []uint32, err error) {
+func GetSchedulerInfo(ctx context.Context, valset entity.ValidatorSet, config entity.NetworkConfig) (aggIndices []uint32, commIndices []uint32, err error) {
 	// ensure validators sorted already, function expects sorted list
 	if err := valset.Validators.CheckIsSortedByOperatorAddressAsc(); err != nil {
 		return nil, nil, err
@@ -172,7 +172,7 @@ func (v *Deriver) GetSchedulerInfo(ctx context.Context, valset entity.ValidatorS
 			).Bytes())
 
 		startIndex := new(big.Int).Mod(hash, big.NewInt(int64(validatorCount))).Uint64()
-		foundIndex := v.findNextAvailableIndex(uint32(startIndex), validatorCount, aggregatorIndices)
+		foundIndex := findNextAvailableIndex(uint32(startIndex), validatorCount, aggregatorIndices)
 		aggregatorIndices[foundIndex] = struct{}{}
 	}
 
@@ -185,7 +185,7 @@ func (v *Deriver) GetSchedulerInfo(ctx context.Context, valset entity.ValidatorS
 			).Bytes())
 
 		startIndex := new(big.Int).Mod(hash, big.NewInt(int64(validatorCount))).Uint64()
-		foundIndex := v.findNextAvailableIndex(uint32(startIndex), validatorCount, committerIndices)
+		foundIndex := findNextAvailableIndex(uint32(startIndex), validatorCount, committerIndices)
 		committerIndices[foundIndex] = struct{}{}
 	}
 
@@ -193,7 +193,7 @@ func (v *Deriver) GetSchedulerInfo(ctx context.Context, valset entity.ValidatorS
 }
 
 // Helper function for wrap-around search
-func (v *Deriver) findNextAvailableIndex(startIndex uint32, validatorCount int, usedIndices map[uint32]struct{}) uint32 {
+func findNextAvailableIndex(startIndex uint32, validatorCount int, usedIndices map[uint32]struct{}) uint32 {
 	for offset := 0; offset < validatorCount; offset++ {
 		candidateIndex := (startIndex + uint32(offset)) % uint32(validatorCount)
 		if _, exists := usedIndices[candidateIndex]; !exists {

--- a/core/usecase/valset-deriver/valset_deriver_test.go
+++ b/core/usecase/valset-deriver/valset_deriver_test.go
@@ -1027,10 +1027,7 @@ func TestDeriver_GetSchedulerInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := NewDeriver(nil)
-			require.NoError(t, err)
-
-			aggIndices, commIndices, err := d.GetSchedulerInfo(context.Background(), tt.valset, tt.config)
+			aggIndices, commIndices, err := GetSchedulerInfo(context.Background(), tt.valset, tt.config)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -1079,15 +1076,12 @@ func TestDeriver_GetSchedulerInfo_Deterministic(t *testing.T) {
 		NumCommitters:  1,
 	}
 
-	d, err := NewDeriver(nil)
-	require.NoError(t, err)
-
 	// Run the same calculation multiple times
 	const iterations = 10
 	var firstAggIndices, firstCommIndices []uint32
 
 	for i := 0; i < iterations; i++ {
-		aggIndices, commIndices, err := d.GetSchedulerInfo(context.Background(), valset, config)
+		aggIndices, commIndices, err := GetSchedulerInfo(context.Background(), valset, config)
 		require.NoError(t, err)
 
 		if i == 0 {
@@ -1133,17 +1127,14 @@ func TestDeriver_GetSchedulerInfo_VerifyRandomness(t *testing.T) {
 		NumCommitters:  1,
 	}
 
-	d, err := NewDeriver(nil)
-	require.NoError(t, err)
-
 	// Get results for original valset
-	aggIndices1, commIndices1, err := d.GetSchedulerInfo(context.Background(), baseValset, config)
+	aggIndices1, commIndices1, err := GetSchedulerInfo(context.Background(), baseValset, config)
 	require.NoError(t, err)
 
 	// Test with different epoch
 	valsetDifferentEpoch := baseValset
 	valsetDifferentEpoch.Epoch = 101
-	aggIndices2, commIndices2, err := d.GetSchedulerInfo(context.Background(), valsetDifferentEpoch, config)
+	aggIndices2, commIndices2, err := GetSchedulerInfo(context.Background(), valsetDifferentEpoch, config)
 	require.NoError(t, err)
 
 	// Note: Different epochs might produce the same results due to hash collisions,
@@ -1154,7 +1145,7 @@ func TestDeriver_GetSchedulerInfo_VerifyRandomness(t *testing.T) {
 	// Test with different timestamp
 	valsetDifferentTimestamp := baseValset
 	valsetDifferentTimestamp.CaptureTimestamp = 9876543210
-	aggIndices3, commIndices3, err := d.GetSchedulerInfo(context.Background(), valsetDifferentTimestamp, config)
+	aggIndices3, commIndices3, err := GetSchedulerInfo(context.Background(), valsetDifferentTimestamp, config)
 	require.NoError(t, err)
 
 	// Results should be different for different timestamps (high probability)
@@ -1225,10 +1216,7 @@ func TestDeriver_findNextAvailableIndex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := NewDeriver(nil)
-			require.NoError(t, err)
-
-			result := d.findNextAvailableIndex(tt.startIndex, tt.validatorCount, tt.usedIndices)
+			result := findNextAvailableIndex(tt.startIndex, tt.validatorCount, tt.usedIndices)
 			require.Equal(t, tt.expected, result)
 
 			// Verify the result is not in usedIndices
@@ -1242,16 +1230,12 @@ func TestDeriver_findNextAvailableIndex(t *testing.T) {
 }
 
 func TestDeriver_findNextAvailableIndex_Panic(t *testing.T) {
-	// Test that the function panics when no indices are available
-	d, err := NewDeriver(nil)
-	require.NoError(t, err)
-
 	// Create a scenario where all indices are taken
 	usedIndices := map[uint32]struct{}{
 		0: {}, 1: {}, 2: {},
 	}
 
 	require.Panics(t, func() {
-		d.findNextAvailableIndex(0, 3, usedIndices)
+		findNextAvailableIndex(0, 3, usedIndices)
 	}, "should panic when no indices are available")
 }

--- a/e2e/tests/sync_test.go
+++ b/e2e/tests/sync_test.go
@@ -63,7 +63,7 @@ func TestAggregatorSignatureSync(t *testing.T) {
 	valset.Epoch++
 	valset.CaptureTimestamp += deploymentData.Env.EpochTime
 
-	aggIndices, commIndices, err := deriver.GetSchedulerInfo(t.Context(), valset, nwConfig)
+	aggIndices, commIndices, err := valsetDeriver.GetSchedulerInfo(t.Context(), valset, nwConfig)
 	require.NoError(t, err, "Failed to get scheduler info")
 	require.NotEmpty(t, aggIndices, "No aggregators found in scheduler info")
 	require.NotEmpty(t, commIndices, "No committers found in scheduler info")

--- a/internal/client/repository/badger/badger_repository_validator_set.go
+++ b/internal/client/repository/badger/badger_repository_validator_set.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/go-errors/errors"
 	"github.com/samber/lo"
+	valsetDeriver "github.com/symbioticfi/relay/core/usecase/valset-deriver"
 
 	"github.com/symbioticfi/relay/core/entity"
 )
@@ -307,6 +308,19 @@ func (r *Repository) GetValidatorSetByEpoch(ctx context.Context, epoch uint64) (
 			Validators:       validators,
 			Status:           status,
 		}
+
+		cfg, err := r.GetConfigByEpoch(ctx, epoch)
+		if err != nil {
+			return errors.Errorf("failed to get config for epoch %d: %w", epoch, err)
+		}
+
+		aggIndices, commIndices, err := valsetDeriver.GetSchedulerInfo(ctx, vs, cfg)
+		if err != nil {
+			return errors.Errorf("failed to get scheduler info for epoch %d: %w", epoch, err)
+		}
+
+		vs.AggregatorIndices = aggIndices
+		vs.CommitterIndices = commIndices
 
 		return nil
 	})


### PR DESCRIPTION
The scheduler info was missing when retrieving the valset fresh from DB. This PR ensures we calculate the indices when retrieving from db for the first time, from next time it should be in the cache.