### PR TITLE
RELAY-196

### DIFF
--- a/e2e/tests/sync_test.go
+++ b/e2e/tests/sync_test.go
@@ -57,24 +57,15 @@ func TestAggregatorSignatureSync(t *testing.T) {
 	nwConfig, err := evmClient.GetConfig(ctx, captureTimestamp)
 	require.NoError(t, err, "Failed to get network config")
 
-	valset, err := deriver.GetValidatorSet(ctx, currentEpoch, nwConfig)
+	nextEpoch := currentEpoch + 1
+	nextValset, err := deriver.GetValidatorSet(ctx, nextEpoch, nwConfig)
 	require.NoError(t, err, "Failed to get validator set")
 
-	// next valset, we expect nothing to change apart from epoch details
-	valset.Epoch++
-	valset.CaptureTimestamp += deploymentData.Env.EpochTime
-
-	aggIndices, commIndices, err := valsetDeriver.GetSchedulerInfo(ctx, valset, nwConfig)
-	require.NoError(t, err, "Failed to get scheduler info")
-	require.NotEmpty(t, aggIndices, "No aggregators found in scheduler info")
-	require.NotEmpty(t, commIndices, "No committers found in scheduler info")
-	valset.AggregatorIndices = aggIndices
-	valset.CommitterIndices = commIndices
-
 	for i := range globalTestEnv.SidecarConfigs {
-		if valset.IsAggregator(globalTestEnv.SidecarConfigs[i].RequiredSymKey.PublicKey().OnChain()) {
+		onChainKey := globalTestEnv.SidecarConfigs[i].RequiredSymKey.PublicKey().OnChain()
+		if nextValset.IsAggregator(onChainKey) {
 			aggregatorIndexes = append(aggregatorIndexes, i)
-		} else if !valset.IsCommitter(globalTestEnv.SidecarConfigs[i].RequiredSymKey.PublicKey().OnChain()) && valset.IsSigner(globalTestEnv.SidecarConfigs[i].RequiredSymKey.PublicKey().OnChain()) {
+		} else if !nextValset.IsCommitter(onChainKey) && nextValset.IsSigner(onChainKey) {
 			onlySignerIndex = i
 		}
 	}
@@ -100,7 +91,6 @@ func TestAggregatorSignatureSync(t *testing.T) {
 	// During this time, signers will generate signatures but aggregators are offline
 	t.Log("Step 3: Waiting for next epoch to trigger signature generation...")
 
-	nextEpoch := currentEpoch + 1
 	err = waitForEpoch(ctx, evmClient, nextEpoch, 2*time.Minute)
 	require.NoError(t, err, "Failed to wait for next epoch")
 	t.Logf("Reached epoch %d", nextEpoch)


### PR DESCRIPTION
### **User description**
refactor: sync_test


___

### **PR Type**
Enhancement


___

### **Description**
- Simplified validator set handling in sync test

- Removed manual epoch increment and timestamp calculation

- Extracted on-chain key to variable for reuse


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Current Epoch"] --> B["Get Next Epoch Valset"]
  B --> C["Check Aggregator/Signer Roles"]
  C --> D["Stop Aggregators"]
  D --> E["Wait for Next Epoch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync_test.go</strong><dd><code>Simplified validator set handling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/tests/sync_test.go

<ul><li>Replaced manual validator set modification with direct next epoch <br>retrieval<br> <li> Removed redundant scheduler info calculation<br> <li> Extracted on-chain key to variable for better readability<br> <li> Moved next epoch calculation earlier in the function</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/180/files#diff-4a40b2f4481adacb8454df1cb5b7776bd45b78472b484a8d9fcf718a1f24afdd">+5/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

