### PR TITLE
feat: add proof size metrics

### DIFF
--- a/cmd/relay/root.go
+++ b/cmd/relay/root.go
@@ -223,6 +223,7 @@ func runApp(ctx context.Context) error {
 		Aggregator:      agg,
 		PollingInterval: time.Second * 5,
 		KeyProvider:     keyProvider,
+		Metrics:         mtr,
 	})
 	if err != nil {
 		return errors.Errorf("failed to create epoch listener: %w", err)

--- a/internal/usecase/valset-generator/valset_generator_handle_agg_proof.go
+++ b/internal/usecase/valset-generator/valset_generator_handle_agg_proof.go
@@ -63,6 +63,11 @@ func (s *Service) HandleProofAggregated(ctx context.Context, msg entity.Aggregat
 		slog.DebugContext(ctx, "Proof commit is already pending, skipping", "epoch", msg.Epoch)
 		return nil
 	}
+
+	if s.cfg.Metrics != nil {
+		s.cfg.Metrics.ObserveAggregationProofSize(len(msg.Proof), len(valset.Validators))
+	}
+
 	slog.DebugContext(ctx, "Marked proof commit as pending", "epoch", msg.Epoch, "request_id", msg.RequestID().Hex())
 	return nil
 }

--- a/internal/usecase/valset-generator/valset_generator_uc.go
+++ b/internal/usecase/valset-generator/valset_generator_uc.go
@@ -58,6 +58,10 @@ type deriver interface {
 	GetNetworkData(ctx context.Context, addr entity.CrossChainAddress) (entity.NetworkData, error)
 }
 
+type metrics interface {
+	ObserveAggregationProofSize(proofSize int, validatorCount int)
+}
+
 type Config struct {
 	Signer          signer        `validate:"required"`
 	EvmClient       evmClient     `validate:"required"`
@@ -66,6 +70,7 @@ type Config struct {
 	PollingInterval time.Duration `validate:"required,gt=0"`
 	KeyProvider     keyprovider.KeyProvider
 	Aggregator      aggregator.Aggregator
+	Metrics         metrics
 }
 
 func (c Config) Validate() error {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add aggregation proof size metrics with histogram tracking

- Integrate metrics into valset generator configuration

- Track proof sizes by active validator count


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Metrics Config"] --> B["Valset Generator"]
  B --> C["HandleProofAggregated"]
  C --> D["ObserveAggregationProofSize"]
  D --> E["Histogram with Validator Count Labels"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>root.go</strong><dd><code>Wire metrics into valset generator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/relay/root.go

- Add metrics parameter to valset generator configuration


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/189/files#diff-c1698ba36d063bfa002e73dd2d0a518c17e10cbcb5b4895f3a9b31864bc9dbdb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metrics.go</strong><dd><code>Implement aggregation proof size histogram metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/metrics/metrics.go

<ul><li>Add <code>aggregationProofSize</code> histogram metric with validator count labels<br> <li> Define proof size buckets from 256B to 1MB<br> <li> Add <code>ObserveAggregationProofSize</code> method for recording metrics<br> <li> Reorganize struct fields with comments for better grouping</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/189/files#diff-bd9e2b45f2d8bd49e5cddad0b05f5971fd036df143c86aa882012adccb090744">+41/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>valset_generator_handle_agg_proof.go</strong><dd><code>Add proof size metrics observation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/valset-generator/valset_generator_handle_agg_proof.go

<ul><li>Call metrics observation when handling aggregated proofs<br> <li> Record proof size and active validator count</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/189/files#diff-9e63149fdf33288bbe2481cb959017b16ab7c5fa2b8006a6b1d6031696a1af48">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>valset_generator_uc.go</strong><dd><code>Define metrics interface and config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/valset-generator/valset_generator_uc.go

<ul><li>Add <code>metrics</code> interface with <code>ObserveAggregationProofSize</code> method<br> <li> Add <code>Metrics</code> field to configuration struct</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/189/files#diff-2bf2060bf29b24fb4e5d3d391ace5487ee56009d3f9aaa5917fd990cf3807f67">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

