### PR TITLE
fix: adjust signature limit handling and update tests

### DIFF
--- a/internal/usecase/sync-provider/sync_provider_handle_want_signatures.go
+++ b/internal/usecase/sync-provider/sync_provider_handle_want_signatures.go
@@ -38,7 +38,8 @@ func (s *Syncer) HandleWantSignaturesRequest(ctx context.Context, request entity
 	for requestID, requestedIndices := range request.WantSignatures {
 		// Check signature count limit before processing each request
 		if totalSignatureCount >= s.cfg.MaxResponseSignatureCount {
-			return entity.WantSignaturesResponse{}, errors.Errorf("response signature limit exceeded")
+			slog.DebugContext(ctx, "Response signature limit reached, stopping collection", "total_collected", totalSignatureCount, "limit", s.cfg.MaxResponseSignatureCount)
+			break
 		}
 
 		var validatorSigs []entity.ValidatorSignature
@@ -49,7 +50,8 @@ func (s *Syncer) HandleWantSignaturesRequest(ctx context.Context, request entity
 			validatorIndex := it.Next()
 			// Check limit before processing each signature
 			if totalSignatureCount >= s.cfg.MaxResponseSignatureCount {
-				return entity.WantSignaturesResponse{}, errors.Errorf("response signature limit exceeded")
+				slog.DebugContext(ctx, "Response signature limit reached during iteration, stopping", "total_collected", totalSignatureCount, "limit", s.cfg.MaxResponseSignatureCount, "request_id", requestID.Hex())
+				break
 			}
 
 			// Get signature by validator index directly

--- a/internal/usecase/sync-provider/sync_provider_test.go
+++ b/internal/usecase/sync-provider/sync_provider_test.go
@@ -380,9 +380,10 @@ func TestHandleWantSignaturesRequest_MaxResponseSignatureCountLimit(t *testing.T
 			},
 		}
 
-		_, err = syncer.HandleWantSignaturesRequest(t.Context(), request)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "response signature limit exceeded")
+		response, err := syncer.HandleWantSignaturesRequest(t.Context(), request)
+		require.NoError(t, err)
+		require.Len(t, response.Signatures, 1)
+		require.Len(t, response.Signatures[requestID], 2) // Should return only 2 signatures due to limit
 	})
 
 	t.Run("limit respected", func(t *testing.T) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace error throwing with graceful signature collection limit handling

- Update tests to verify partial signature collection behavior

- Add debug logging for signature limit reached scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request Signatures"] --> B["Check Limit"]
  B --> C["Limit Exceeded?"]
  C -->|Yes| D["Log & Break Collection"]
  C -->|No| E["Collect Signature"]
  E --> F["Continue Processing"]
  D --> G["Return Partial Results"]
  F --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync_provider_handle_want_signatures.go</strong><dd><code>Replace limit errors with graceful collection stopping</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/sync-provider/sync_provider_handle_want_signatures.go

<ul><li>Replace error returns with break statements when signature limit <br>exceeded<br> <li> Add debug logging with collection statistics and request context<br> <li> Allow partial signature collection instead of complete failure</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/209/files#diff-c4ab5eadef9854753d506076077313210cbe402321e3c10dabaca9514fea92c2">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync_provider_test.go</strong><dd><code>Update tests for partial signature collection behavior</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/sync-provider/sync_provider_test.go

<ul><li>Update test to expect successful response instead of error<br> <li> Verify partial signature collection (2 out of 5 requested)<br> <li> Assert response structure contains expected limited results</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/209/files#diff-06b10f37763d25a55ce29018adbc2fa196a020cce2679d2c0cf35659a34db2a5">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

