### PR TITLE
feat improve commitment catchup logic

### DIFF
--- a/internal/usecase/valset-listener/valset_generator_handle_agg_proof.go
+++ b/internal/usecase/valset-listener/valset_generator_handle_agg_proof.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	minCommitterPollIntervalSeconds = uint64(5)
+	commitCheckBatchSize            = 5
 )
 
 func (s *Service) StartCommitterLoop(ctx context.Context) error {
@@ -96,7 +97,7 @@ func (s *Service) StartCommitterLoop(ctx context.Context) error {
 		}
 
 		// get lat committed epoch
-		lastCommittedEpoch := s.detectLastCommittedEpoch(ctx)
+		lastCommittedEpoch := s.detectLastCommittedEpochFromDB(ctx)
 
 		if lastCommittedEpoch >= valset.Epoch {
 			slog.DebugContext(ctx, "No pending proofs to commit, all epochs committed", "lastCommittedEpoch", lastCommittedEpoch, "knownValsetEpoch", valset.Epoch)
@@ -105,7 +106,22 @@ func (s *Service) StartCommitterLoop(ctx context.Context) error {
 
 		slog.DebugContext(ctx, "Detected last committed epoch", "lastCommittedEpoch", lastCommittedEpoch, "knownValsetEpoch", valset.Epoch)
 
-		pendingProofs, err := s.cfg.Repo.GetPendingProofCommitsSinceEpoch(ctx, lastCommittedEpoch+1, 5)
+		// Dev: we check if the no. of uncommitted epochs is > the batch size then there's a chance
+		// that we might've already committed some epochs but those are not finalized,
+		// hence to optimize for both time and network calls we directly check on the
+		// settlement layers to see what's the latest(not finalized) commit
+		if valset.Epoch-lastCommittedEpoch > symbiotic.Epoch(commitCheckBatchSize) {
+			newLastCommit := s.detectLastCommittedEpochFromChain(ctx, nwCfg)
+			if newLastCommit > lastCommittedEpoch {
+				slog.InfoContext(ctx, "Number of uncommitted epochs exceeds batch size, updated last committed epoch based on settlement chain data",
+					"oldLastCommittedEpoch", lastCommittedEpoch,
+					"newLastCommittedEpoch", newLastCommit,
+				)
+				lastCommittedEpoch = newLastCommit
+			}
+		}
+
+		pendingProofs, err := s.cfg.Repo.GetPendingProofCommitsSinceEpoch(ctx, lastCommittedEpoch+1, commitCheckBatchSize)
 		if err != nil {
 			return errors.Errorf("failed to get pending proof commits since epoch %d: %w", valset.Epoch, err)
 		}
@@ -174,7 +190,7 @@ func (s *Service) processPendingProof(ctx context.Context, proofKey symbiotic.Pr
 	return nil
 }
 
-func (s *Service) detectLastCommittedEpoch(ctx context.Context) symbiotic.Epoch {
+func (s *Service) detectLastCommittedEpochFromDB(ctx context.Context) symbiotic.Epoch {
 	uncommitted, err := s.cfg.Repo.GetFirstUncommittedValidatorSetEpoch(ctx)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
@@ -185,6 +201,24 @@ func (s *Service) detectLastCommittedEpoch(ctx context.Context) symbiotic.Epoch 
 		return symbiotic.Epoch(0)
 	}
 	return uncommitted - 1
+}
+
+func (s *Service) detectLastCommittedEpochFromChain(ctx context.Context, config symbiotic.NetworkConfig) symbiotic.Epoch {
+	minVal := symbiotic.Epoch(0)
+	for _, settlement := range config.Settlements {
+		lastCommittedEpoch, err := s.cfg.EvmClient.GetLastCommittedHeaderEpoch(ctx, settlement, symbiotic.WithEVMBlockNumber(symbiotic.BlockNumberLatest))
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to get last committed epoch for settlement, skipping", "settlement", settlement, "error", err)
+			// skip chain if networking issue, we will recheck again anyway and if the rpc/chain recovers we will detect issue later
+			continue
+		}
+		if minVal == 0 {
+			minVal = lastCommittedEpoch
+		} else if lastCommittedEpoch < minVal {
+			minVal = lastCommittedEpoch
+		}
+	}
+	return minVal
 }
 
 // commitValsetToAllSettlements commits the validator set header to all configured settlement chains.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add batch-based commitment catchup optimization logic

- Rename detection method to clarify DB-based epoch detection

- Implement chain-based epoch detection for uncommitted epochs

- Check settlement layers when uncommitted epochs exceed batch size


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Detect Last Committed Epoch"] --> B{"Uncommitted Epochs > Batch Size?"}
  B -->|Yes| C["Check Settlement Chain"]
  B -->|No| D["Use DB Records"]
  C --> E["Update Last Committed Epoch"]
  D --> E
  E --> F["Fetch Pending Proofs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>valset_generator_handle_agg_proof.go</strong><dd><code>Add chain-based epoch detection and batch optimization</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/valset-listener/valset_generator_handle_agg_proof.go

<ul><li>Add <code>commitCheckBatchSize</code> constant set to 5 for batch processing<br> <li> Rename <code>detectLastCommittedEpoch()</code> to <code>detectLastCommittedEpochFromDB()</code> <br>for clarity<br> <li> Implement new <code>detectLastCommittedEpochFromChain()</code> method to query <br>settlement layers<br> <li> Add optimization logic to check chain when uncommitted epochs exceed <br>batch size threshold<br> <li> Use <code>commitCheckBatchSize</code> variable in pending proofs query instead of <br>hardcoded value</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/283/files#diff-030c09bc477b1af583f48d7d5414af2c75d9182b73816c1f16d99b90b2e85011">+37/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

