### PR TITLE
feat: do not block commitments on partial failure

### DIFF
--- a/internal/usecase/valset-listener/valset_generator_handle_agg_proof.go
+++ b/internal/usecase/valset-listener/valset_generator_handle_agg_proof.go
@@ -287,5 +287,5 @@ func (s *Service) commitValsetToAllSettlements(ctx context.Context, config symbi
 		)
 	}
 
-	return len(errs) != len(config.Settlements), errors.Join(errs...)
+	return len(config.Settlements) == 0 || len(errs) != len(config.Settlements), errors.Join(errs...)
 }


### PR DESCRIPTION
This PR ensures that the commitment loop doesn't stop on partial failure to commit to a settlement. As long as there's at least 1 successful commit, committer should continue committing epochs.