### PR TITLE
fix: enforce required key tags in valset derivation

### DIFF
--- a/symbiotic/usecase/valset-deriver/valset_deriver.go
+++ b/symbiotic/usecase/valset-deriver/valset_deriver.go
@@ -296,8 +296,9 @@ func markValidatorsActive(config symbiotic.NetworkConfig, validators symbiotic.V
 			break
 		}
 
-		// Check if validator has at least one key
-		if len(validators[i].Keys) == 0 {
+		// Validators must have at least one key, and when configured,
+		// they must include every required key tag.
+		if !hasRequiredKeys(validators[i], config.RequiredKeyTags) {
 			continue
 		}
 
@@ -316,6 +317,29 @@ func markValidatorsActive(config symbiotic.NetworkConfig, validators symbiotic.V
 			}
 		}
 	}
+}
+
+func hasRequiredKeys(validator symbiotic.Validator, requiredKeyTags []symbiotic.KeyTag) bool {
+	if len(validator.Keys) == 0 {
+		return false
+	}
+
+	if len(requiredKeyTags) == 0 {
+		return true
+	}
+
+	availableTags := make(map[symbiotic.KeyTag]struct{}, len(validator.Keys))
+	for _, key := range validator.Keys {
+		availableTags[key.Tag] = struct{}{}
+	}
+
+	for _, tag := range requiredKeyTags {
+		if _, ok := availableTags[tag]; !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 func fillValidators(votingPowers []dtoOperatorVotingPower, keys []symbiotic.OperatorWithKeys) symbiotic.Validators {

--- a/symbiotic/usecase/valset-deriver/valset_deriver_test.go
+++ b/symbiotic/usecase/valset-deriver/valset_deriver_test.go
@@ -529,6 +529,76 @@ func TestDeriver_fillValidatorsActive(t *testing.T) {
 			},
 		},
 		{
+			name: "validator missing one required key tag should be inactive",
+			config: symbiotic.NetworkConfig{
+				MinInclusionVotingPower: symbiotic.ToVotingPower(big.NewInt(100)),
+				MaxVotingPower:          symbiotic.ToVotingPower(big.NewInt(0)),
+				MaxValidatorsCount:      symbiotic.ToVotingPower(big.NewInt(0)),
+				RequiredKeyTags:         []symbiotic.KeyTag{15, 16},
+			},
+			validators: symbiotic.Validators{
+				{
+					Operator:    common.HexToAddress("0x123"),
+					VotingPower: symbiotic.ToVotingPower(big.NewInt(500)),
+					IsActive:    false,
+					Keys: []symbiotic.ValidatorKey{
+						{Tag: symbiotic.KeyTag(15), Payload: symbiotic.CompactPublicKey("key1")},
+					},
+				},
+				{
+					Operator:    common.HexToAddress("0x456"),
+					VotingPower: symbiotic.ToVotingPower(big.NewInt(300)),
+					IsActive:    false,
+					Keys: []symbiotic.ValidatorKey{
+						{Tag: symbiotic.KeyTag(15), Payload: symbiotic.CompactPublicKey("key2")},
+						{Tag: symbiotic.KeyTag(16), Payload: symbiotic.CompactPublicKey("key3")},
+					},
+				},
+			},
+			expectedTotalVotingPower:   big.NewInt(300),
+			expectedActiveValidators:   []common.Address{common.HexToAddress("0x456")},
+			expectedInactiveValidators: []common.Address{common.HexToAddress("0x123")},
+			expectedVotingPowers: map[string]*big.Int{
+				"0x123": big.NewInt(500),
+				"0x456": big.NewInt(300),
+			},
+		},
+		{
+			name: "validator with all required key tags should be active",
+			config: symbiotic.NetworkConfig{
+				MinInclusionVotingPower: symbiotic.ToVotingPower(big.NewInt(100)),
+				MaxVotingPower:          symbiotic.ToVotingPower(big.NewInt(0)),
+				MaxValidatorsCount:      symbiotic.ToVotingPower(big.NewInt(0)),
+				RequiredKeyTags:         []symbiotic.KeyTag{15, 16},
+			},
+			validators: symbiotic.Validators{
+				{
+					Operator:    common.HexToAddress("0x123"),
+					VotingPower: symbiotic.ToVotingPower(big.NewInt(500)),
+					IsActive:    false,
+					Keys: []symbiotic.ValidatorKey{
+						{Tag: symbiotic.KeyTag(15), Payload: symbiotic.CompactPublicKey("key1")},
+						{Tag: symbiotic.KeyTag(16), Payload: symbiotic.CompactPublicKey("key2")},
+					},
+				},
+				{
+					Operator:    common.HexToAddress("0x456"),
+					VotingPower: symbiotic.ToVotingPower(big.NewInt(300)),
+					IsActive:    false,
+					Keys: []symbiotic.ValidatorKey{
+						{Tag: symbiotic.KeyTag(15), Payload: symbiotic.CompactPublicKey("key3")},
+					},
+				},
+			},
+			expectedTotalVotingPower:   big.NewInt(500),
+			expectedActiveValidators:   []common.Address{common.HexToAddress("0x123")},
+			expectedInactiveValidators: []common.Address{common.HexToAddress("0x456")},
+			expectedVotingPowers: map[string]*big.Int{
+				"0x123": big.NewInt(500),
+				"0x456": big.NewInt(300),
+			},
+		},
+		{
 			name: "max voting power capping",
 			config: symbiotic.NetworkConfig{
 				MinInclusionVotingPower: symbiotic.ToVotingPower(big.NewInt(100)),


### PR DESCRIPTION
### **User description**
Idk if you're currently taking os contributions, but while reading through the codebase I noticed a few TODOs and decided to pick this one up.
From what I understood, validator activation in valset derivation only checked whether a validator had any key at all. But since `RequiredKeyTags` exists in `NetworkConfig`, it felt like validators should only become active if they actually satisfy those configured key requirements.

So this change updates the activation logic to require all configured `RequiredKeyTags` when determining whether a validator becomes active, and adds tests to cover that behavior.

Would be glad to work on more of them(TODOs/issues) too if contributions are welcome.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforce configured required key tags

- Keep validators inactive without full keys

- Add valset derivation coverage

- Verify active and inactive outcomes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["Network config RequiredKeyTags"]
  check["hasRequiredKeys() validation"]
  active["Validator marked active"]
  inactive["Validator skipped as inactive"]
  tests["Deriver test cases"]
  cfg -- "drives" --> check
  check -- "all tags present" --> active
  check -- "missing tags or no keys" --> inactive
  tests -- "verifies" --> check
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>valset_deriver.go</strong><dd><code>Enforce required key tags for activation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

symbiotic/usecase/valset-deriver/valset_deriver.go

<ul><li>Replace the old non-empty key check with <code>hasRequiredKeys</code><br> <li> Require validators to include every configured <code>RequiredKeyTags</code><br> <li> Keep validators without keys inactive<br> <li> Add helper logic to compare available versus required tags</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/406/files#diff-2384da0a822462245bdcf63203ab684f42dd52665ebbc5292e5f937ec4ad694a">+26/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>valset_deriver_test.go</strong><dd><code>Cover required key tag activation rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

symbiotic/usecase/valset-deriver/valset_deriver_test.go

<ul><li>Add test case for a validator missing one required tag<br> <li> Add test case for a validator satisfying all required tags<br> <li> Assert expected active validators and total voting power<br> <li> Confirm validators without full required keys stay inactive</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/406/files#diff-2d4b6ef78020b9d1404485e8080681ee1fb09be0659b63a5400525419f9ba54c">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

