### PR TITLE
fix: support multichain key registration

### DIFF
--- a/cmd/utils/operator/register_key.go
+++ b/cmd/utils/operator/register_key.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"strconv"
 	"time"
 
@@ -71,6 +72,9 @@ var registerKeyCmd = &cobra.Command{
 		chainId, err := registerKeyChainID(ctx, evmClient)
 		if err != nil {
 			return errors.Errorf("failed to resolve key registry chain: %w", err)
+		}
+		if !hasConfiguredChain(evmClient.GetChains(), chainId) {
+			return errors.Errorf("keys provider chain %d is not configured", chainId)
 		}
 
 		privateKeyInput := pterm.DefaultInteractiveTextInput.WithMask("*")
@@ -150,4 +154,8 @@ func registerKeyChainID(ctx context.Context, evmClient evm.IEvmClient) (uint64, 
 	}
 
 	return networkConfig.KeysProvider.ChainId, nil
+}
+
+func hasConfiguredChain(configuredChainIDs []uint64, targetChainID uint64) bool {
+	return slices.Contains(configuredChainIDs, targetChainID)
 }

--- a/cmd/utils/operator/register_key.go
+++ b/cmd/utils/operator/register_key.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"log/slog"
 	"strconv"
 	"time"
@@ -20,6 +21,27 @@ import (
 	symbioticCrypto "github.com/symbioticfi/relay/symbiotic/usecase/crypto"
 )
 
+type registerKeyBuilder interface {
+	Register(
+		ctx context.Context,
+		pk symbioticCrypto.PrivateKey,
+		kt symbiotic.KeyTag,
+		operatorAddress common.Address,
+	) (symbiotic.TxResult, error)
+}
+
+var newRegisterKeyMetrics = func() *metrics.Metrics {
+	return metrics.New(metrics.Config{})
+}
+
+var newRegisterKeyEVMClient = func(ctx context.Context, cfg evm.Config) (evm.IEvmClient, error) {
+	return evm.NewEvmClient(ctx, cfg)
+}
+
+var newRegisterKeyBuilder = func(evmClient evm.IEvmClient) (registerKeyBuilder, error) {
+	return key_registerer.NewRegisterer(key_registerer.Config{EVMClient: evmClient})
+}
+
 var registerKeyCmd = &cobra.Command{
 	Use:   "register-key",
 	Short: "Register operator key in key registry",
@@ -32,7 +54,7 @@ var registerKeyCmd = &cobra.Command{
 			return err
 		}
 
-		evmClient, err := evm.NewEvmClient(ctx, evm.Config{
+		evmClient, err := newRegisterKeyEVMClient(ctx, evm.Config{
 			ChainURLs: globalFlags.Chains,
 			DriverAddress: symbiotic.CrossChainAddress{
 				ChainId: globalFlags.DriverChainId,
@@ -40,17 +62,16 @@ var registerKeyCmd = &cobra.Command{
 			},
 			RequestTimeout: 5 * time.Second,
 			KeyProvider:    kp,
-			Metrics:        metrics.New(metrics.Config{}),
+			Metrics:        newRegisterKeyMetrics(),
 		})
 		if err != nil {
 			return err
 		}
 
-		// TODO multiple chains key registration support
-		if len(evmClient.GetChains()) != 1 {
-			return errors.New("only single chain is supported")
+		chainId, err := registerKeyChainID(ctx, evmClient)
+		if err != nil {
+			return errors.Errorf("failed to resolve key registry chain: %w", err)
 		}
-		chainId := evmClient.GetChains()[0]
 
 		privateKeyInput := pterm.DefaultInteractiveTextInput.WithMask("*")
 		secret, ok := registerKeyFlags.Secrets.Secrets[chainId]
@@ -95,9 +116,7 @@ var registerKeyCmd = &cobra.Command{
 		}
 		operator := crypto.PubkeyToAddress(ecdsaPk.PublicKey)
 
-		keyReg, err := key_registerer.NewRegisterer(key_registerer.Config{
-			EVMClient: evmClient,
-		})
+		keyReg, err := newRegisterKeyBuilder(evmClient)
 		if err != nil {
 			return errors.Errorf("failed to create registerer: %w", err)
 		}
@@ -112,4 +131,23 @@ var registerKeyCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func registerKeyChainID(ctx context.Context, evmClient evm.IEvmClient) (uint64, error) {
+	currentOnchainEpoch, err := evmClient.GetCurrentEpoch(ctx)
+	if err != nil {
+		return 0, errors.Errorf("failed to get current epoch: %w", err)
+	}
+
+	captureTimestamp, err := evmClient.GetEpochStart(ctx, currentOnchainEpoch)
+	if err != nil {
+		return 0, errors.Errorf("failed to get capture timestamp: %w", err)
+	}
+
+	networkConfig, err := evmClient.GetConfig(ctx, captureTimestamp, currentOnchainEpoch)
+	if err != nil {
+		return 0, errors.Errorf("failed to get config: %w", err)
+	}
+
+	return networkConfig.KeysProvider.ChainId, nil
 }

--- a/cmd/utils/operator/register_key_test.go
+++ b/cmd/utils/operator/register_key_test.go
@@ -1,0 +1,113 @@
+package operator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/symbioticfi/relay/internal/usecase/metrics"
+	"github.com/symbioticfi/relay/symbiotic/client/evm"
+	evmmocks "github.com/symbioticfi/relay/symbiotic/client/evm/mocks"
+	symbiotic "github.com/symbioticfi/relay/symbiotic/entity"
+	symbioticCrypto "github.com/symbioticfi/relay/symbiotic/usecase/crypto"
+)
+
+func TestRegisterKeyUsesKeysProviderChainSecret(t *testing.T) {
+	keyTag, err := symbiotic.KeyTagFromTypeAndId(symbiotic.KeyTypeEcdsaSecp256k1, 1)
+	require.NoError(t, err)
+
+	relayKeyBytes := make([]byte, 32)
+	relayKeyBytes[len(relayKeyBytes)-1] = 0x66
+
+	relayKey, err := symbioticCrypto.NewPrivateKey(symbiotic.KeyTypeEcdsaSecp256k1, relayKeyBytes)
+	require.NoError(t, err)
+
+	keystorePath := createOperatorTestKeystore(t, keyTag, relayKey)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEVMClient := evmmocks.NewMockIEvmClient(ctrl)
+	mockEVMClient.EXPECT().GetCurrentEpoch(gomock.Any()).Return(symbiotic.Epoch(7), nil)
+	mockEVMClient.EXPECT().GetEpochStart(gomock.Any(), symbiotic.Epoch(7)).Return(symbiotic.Timestamp(123), nil)
+	mockEVMClient.EXPECT().GetConfig(gomock.Any(), symbiotic.Timestamp(123), symbiotic.Epoch(7)).Return(symbiotic.NetworkConfig{
+		KeysProvider: symbiotic.CrossChainAddress{
+			ChainId: 137,
+			Address: common.HexToAddress("0x0000000000000000000000000000000000000137"),
+		},
+	}, nil)
+
+	builder := &capturingRegisterKeyBuilder{}
+	restore := stubRegisterKeyCommandDependencies(t, mockEVMClient, builder)
+	defer restore()
+
+	chainOneSecret := "1111111111111111111111111111111111111111111111111111111111111111"
+	keysProviderSecret := "2222222222222222222222222222222222222222222222222222222222222222"
+
+	output, err := runOperatorCommand(t,
+		"register-key",
+		"--key-tag", keyTagArg(keyTag),
+		"--path", keystorePath,
+		"--password", testKeystorePassword,
+		"--secret-keys", "1:"+chainOneSecret+",137:"+keysProviderSecret,
+	)
+	require.NoError(t, err, output)
+	require.True(t, builder.registerCalled)
+
+	expectedOperator, err := operatorAddressFromSecret(keysProviderSecret)
+	require.NoError(t, err)
+	require.Equal(t, expectedOperator, builder.operatorAddress)
+}
+
+func stubRegisterKeyCommandDependencies(t *testing.T, evmClient *evmmocks.MockIEvmClient, builder registerKeyBuilder) func() {
+	t.Helper()
+
+	originalClientFactory := newRegisterKeyEVMClient
+	originalBuilderFactory := newRegisterKeyBuilder
+	originalMetricsFactory := newRegisterKeyMetrics
+
+	newRegisterKeyMetrics = func() *metrics.Metrics {
+		return metrics.New(metrics.Config{Registerer: prometheus.NewRegistry()})
+	}
+	newRegisterKeyEVMClient = func(_ context.Context, _ evm.Config) (evm.IEvmClient, error) {
+		return evmClient, nil
+	}
+	newRegisterKeyBuilder = func(evm.IEvmClient) (registerKeyBuilder, error) {
+		return builder, nil
+	}
+
+	return func() {
+		newRegisterKeyMetrics = originalMetricsFactory
+		newRegisterKeyEVMClient = originalClientFactory
+		newRegisterKeyBuilder = originalBuilderFactory
+	}
+}
+
+type capturingRegisterKeyBuilder struct {
+	registerCalled  bool
+	operatorAddress common.Address
+}
+
+func (c *capturingRegisterKeyBuilder) Register(
+	_ context.Context,
+	_ symbioticCrypto.PrivateKey,
+	_ symbiotic.KeyTag,
+	operatorAddress common.Address,
+) (symbiotic.TxResult, error) {
+	c.registerCalled = true
+	c.operatorAddress = operatorAddress
+	return symbiotic.TxResult{}, nil
+}
+
+func operatorAddressFromSecret(secret string) (common.Address, error) {
+	privateKey, err := gethcrypto.HexToECDSA(secret)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return gethcrypto.PubkeyToAddress(privateKey.PublicKey), nil
+}

--- a/cmd/utils/operator/register_key_test.go
+++ b/cmd/utils/operator/register_key_test.go
@@ -41,6 +41,7 @@ func TestRegisterKeyUsesKeysProviderChainSecret(t *testing.T) {
 			Address: common.HexToAddress("0x0000000000000000000000000000000000000137"),
 		},
 	}, nil)
+	mockEVMClient.EXPECT().GetChains().Return([]uint64{1, 137})
 
 	builder := &capturingRegisterKeyBuilder{}
 	restore := stubRegisterKeyCommandDependencies(t, mockEVMClient, builder)
@@ -62,6 +63,37 @@ func TestRegisterKeyUsesKeysProviderChainSecret(t *testing.T) {
 	expectedOperator, err := operatorAddressFromSecret(keysProviderSecret)
 	require.NoError(t, err)
 	require.Equal(t, expectedOperator, builder.operatorAddress)
+}
+
+func TestRegisterKeyFailsWhenKeysProviderChainIsNotConfigured(t *testing.T) {
+	keyTag, err := symbiotic.KeyTagFromTypeAndId(symbiotic.KeyTypeEcdsaSecp256k1, 1)
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEVMClient := evmmocks.NewMockIEvmClient(ctrl)
+	mockEVMClient.EXPECT().GetCurrentEpoch(gomock.Any()).Return(symbiotic.Epoch(7), nil)
+	mockEVMClient.EXPECT().GetEpochStart(gomock.Any(), symbiotic.Epoch(7)).Return(symbiotic.Timestamp(123), nil)
+	mockEVMClient.EXPECT().GetConfig(gomock.Any(), symbiotic.Timestamp(123), symbiotic.Epoch(7)).Return(symbiotic.NetworkConfig{
+		KeysProvider: symbiotic.CrossChainAddress{
+			ChainId: 137,
+			Address: common.HexToAddress("0x0000000000000000000000000000000000000137"),
+		},
+	}, nil)
+	mockEVMClient.EXPECT().GetChains().Return([]uint64{1})
+
+	builder := &capturingRegisterKeyBuilder{}
+	restore := stubRegisterKeyCommandDependencies(t, mockEVMClient, builder)
+	defer restore()
+
+	output, err := runOperatorCommand(t,
+		"register-key",
+		"--key-tag", keyTagArg(keyTag),
+	)
+	require.EqualError(t, err, "keys provider chain 137 is not configured")
+	require.Contains(t, output, "keys provider chain 137 is not configured")
+	require.False(t, builder.registerCalled)
 }
 
 func stubRegisterKeyCommandDependencies(t *testing.T, evmClient *evmmocks.MockIEvmClient, builder registerKeyBuilder) func() {


### PR DESCRIPTION
### **User description**
In addition to #406, saw this TODO about supporting multichain key registration and decided to pick it up too.

From what I understood, `register-key` was still assuming a single-chain setup and would fail otherwise. This updates it to resolve the key registry chain from the network config and use the secret for that specific chain instead.



Added a test around the multichain process works fine, including the existing test.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Resolve key registry chain dynamically

- Use matching chain secret for registration

- Replace hardcoded single-chain restriction

- Add command test with mocked config


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cmd["register-key command"]
  epoch["Fetch epoch and config"]
  chain["Resolve KeysProvider.ChainId"]
  secret["Select secret for resolved chain"]
  reg["Register key with operator address"]
  test["Mocked multichain command test"]

  cmd -- "queries" --> epoch
  epoch -- "returns" --> chain
  chain -- "drives" --> secret
  secret -- "used by" --> reg
  test -- "verifies" --> secret
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register_key.go</strong><dd><code>Resolve key registration chain from config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/utils/operator/register_key.go

<ul><li>Add injectable factories for client, metrics, and registerer<br> <li> Remove single-chain-only validation from command flow<br> <li> Resolve registry chain via epoch and network config<br> <li> Use resolved chain secret when building operator address</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/411/files#diff-946a76e4facae325a428d64da9d359e39e23258cb49ef8f904a200e52f14e15d">+47/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>register_key_test.go</strong><dd><code>Test multichain secret selection in command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/utils/operator/register_key_test.go

<ul><li>Add test covering keys-provider chain secret selection<br> <li> Mock EVM config lookup for multichain behavior<br> <li> Stub command dependencies for isolated execution<br> <li> Capture registered operator address for assertion</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/411/files#diff-d15ad630d68fba6f35bc01f9e2a72c0223c4be0eaed1d57d8f3a94864fd2658c">+113/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

