### PR TITLE
fix: sorted indices for aggreegator and committer

### DIFF
--- a/symbiotic/usecase/valset-deriver/valset_deriver.go
+++ b/symbiotic/usecase/valset-deriver/valset_deriver.go
@@ -260,7 +260,8 @@ func GetSchedulerInfo(_ context.Context, valset symbiotic.ValidatorSet, config s
 		committerIndices[foundIndex] = struct{}{}
 	}
 
-	return slices.Collect(maps.Keys(aggregatorIndices)), slices.Collect(maps.Keys(committerIndices)), nil
+	// need to return sorted ascending order indices because serialization uses bitmap which only returns sorted values when unpacking
+	return slices.Sorted(maps.Keys(aggregatorIndices)), slices.Sorted(maps.Keys(committerIndices)), nil
 }
 
 // Helper function for wrap-around search


### PR DESCRIPTION
### **User description**
Fixes https://github.com/symbioticfi/relay/issues/453


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve validator scheduler index ordering

- Sort aggregator and committer indices

- Align round-trip with bitmap serialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  a["Scheduler-selected validator indices"]
  b["Sort indices ascending"]
  c["Bitmap header serialization"]
  d["Stable unpacked committer order"]
  a -- "before return" --> b
  b -- "matches" --> c
  c -- "restores" --> d
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>valset_deriver.go</strong><dd><code>Return sorted scheduler indices for stability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

symbiotic/usecase/valset-deriver/valset_deriver.go

<ul><li>Sort <code>aggregatorIndices</code> before returning them<br> <li> Sort <code>committerIndices</code> before returning them<br> <li> Document bitmap serialization ordering requirement<br> <li> Prevent round-trip order mismatches in scheduling</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/454/files#diff-2384da0a822462245bdcf63203ab684f42dd52665ebbc5292e5f937ec4ad694a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

