### PR TITLE
Only mark validator sets aggregated for valset proofs

### DIFF
--- a/internal/usecase/entity-processor/entity_processor.go
+++ b/internal/usecase/entity-processor/entity_processor.go
@@ -23,6 +23,7 @@ type Repository interface {
 	GetSignatureByIndex(ctx context.Context, requestID common.Hash, validatorIndex uint32) (symbiotic.Signature, error)
 	GetValidatorByKey(ctx context.Context, epoch symbiotic.Epoch, keyTag symbiotic.KeyTag, publicKey []byte) (symbiotic.Validator, uint32, error)
 	GetValidatorSetByEpoch(ctx context.Context, epoch symbiotic.Epoch) (symbiotic.ValidatorSet, error)
+	GetValidatorSetMetadata(ctx context.Context, epoch symbiotic.Epoch) (symbiotic.ValidatorSetMetadata, error)
 	GetAggregationProof(ctx context.Context, requestID common.Hash) (symbiotic.AggregationProof, error)
 	SaveProof(ctx context.Context, aggregationProof symbiotic.AggregationProof) error
 	UpdateValidatorSetStatus(ctx context.Context, epoch symbiotic.Epoch, item symbiotic.ValidatorSetStatus) error
@@ -190,8 +191,8 @@ func (s *EntityProcessor) ProcessAggregationProof(ctx context.Context, aggregati
 		return errors.Errorf("failed to add aggregation proof: %w", err)
 	}
 
-	if err := s.cfg.Repo.UpdateValidatorSetStatus(ctx, aggregationProof.Epoch, symbiotic.HeaderAggregated); err != nil {
-		return errors.Errorf("failed to update validator set status: %w", err)
+	if err := s.markValidatorSetAggregatedIfValsetProof(ctx, aggregationProof); err != nil {
+		return err
 	}
 
 	slog.DebugContext(ctx, "Proof saved")
@@ -199,6 +200,26 @@ func (s *EntityProcessor) ProcessAggregationProof(ctx context.Context, aggregati
 	if err := s.cfg.AggProofSignal.Emit(aggregationProof); err != nil {
 		tracing.RecordError(span, err)
 		return errors.Errorf("failed to emit aggregation proof signal: %w", err)
+	}
+
+	return nil
+}
+
+func (s *EntityProcessor) markValidatorSetAggregatedIfValsetProof(ctx context.Context, aggregationProof symbiotic.AggregationProof) error {
+	metadata, err := s.cfg.Repo.GetValidatorSetMetadata(ctx, aggregationProof.Epoch)
+	if err != nil {
+		if errors.Is(err, entity.ErrEntityNotFound) {
+			return nil
+		}
+		return errors.Errorf("failed to get validator set metadata for epoch %d: %w", aggregationProof.Epoch, err)
+	}
+
+	if metadata.RequestID != aggregationProof.RequestID() {
+		return nil
+	}
+
+	if err := s.cfg.Repo.UpdateValidatorSetStatus(ctx, aggregationProof.Epoch, symbiotic.HeaderAggregated); err != nil {
+		return errors.Errorf("failed to update validator set status: %w", err)
 	}
 
 	return nil

--- a/internal/usecase/entity-processor/entity_processor.go
+++ b/internal/usecase/entity-processor/entity_processor.go
@@ -186,13 +186,22 @@ func (s *EntityProcessor) ProcessAggregationProof(ctx context.Context, aggregati
 		}
 	}
 
+	valsetProofTargetEpoch, isValsetProof, err := s.valsetProofTargetEpoch(ctx, aggregationProof)
+	if err != nil {
+		tracing.RecordError(span, err)
+		return err
+	}
+
 	if err := s.cfg.Repo.SaveProof(ctx, aggregationProof); err != nil {
 		tracing.RecordError(span, err)
 		return errors.Errorf("failed to add aggregation proof: %w", err)
 	}
 
-	if err := s.markValidatorSetAggregatedIfValsetProof(ctx, aggregationProof); err != nil {
-		return err
+	if isValsetProof {
+		if err := s.cfg.Repo.UpdateValidatorSetStatus(ctx, valsetProofTargetEpoch, symbiotic.HeaderAggregated); err != nil {
+			tracing.RecordError(span, err)
+			return errors.Errorf("failed to update validator set status: %w", err)
+		}
 	}
 
 	slog.DebugContext(ctx, "Proof saved")
@@ -205,22 +214,22 @@ func (s *EntityProcessor) ProcessAggregationProof(ctx context.Context, aggregati
 	return nil
 }
 
-func (s *EntityProcessor) markValidatorSetAggregatedIfValsetProof(ctx context.Context, aggregationProof symbiotic.AggregationProof) error {
-	metadata, err := s.cfg.Repo.GetValidatorSetMetadata(ctx, aggregationProof.Epoch)
+func (s *EntityProcessor) valsetProofTargetEpoch(
+	ctx context.Context,
+	aggregationProof symbiotic.AggregationProof,
+) (symbiotic.Epoch, bool, error) {
+	targetEpoch := aggregationProof.Epoch + 1
+	metadata, err := s.cfg.Repo.GetValidatorSetMetadata(ctx, targetEpoch)
 	if err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			return nil
+			return 0, false, nil
 		}
-		return errors.Errorf("failed to get validator set metadata for epoch %d: %w", aggregationProof.Epoch, err)
+		return 0, false, errors.Errorf("failed to get validator set metadata for epoch %d: %w", targetEpoch, err)
 	}
 
 	if metadata.RequestID != aggregationProof.RequestID() {
-		return nil
+		return 0, false, nil
 	}
 
-	if err := s.cfg.Repo.UpdateValidatorSetStatus(ctx, aggregationProof.Epoch, symbiotic.HeaderAggregated); err != nil {
-		return errors.Errorf("failed to update validator set status: %w", err)
-	}
-
-	return nil
+	return targetEpoch, true, nil
 }

--- a/internal/usecase/entity-processor/entity_processor_test.go
+++ b/internal/usecase/entity-processor/entity_processor_test.go
@@ -640,6 +640,128 @@ func TestEntityProcessor_ProcessAggregationProof_HandlesMissingPendingGracefully
 	}
 }
 
+func TestEntityProcessor_ProcessAggregationProof_DoesNotUpdateValidatorSetStatusForUnrelatedProof(t *testing.T) {
+	t.Parallel()
+
+	for name, newRepo := range backends() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := newRepo(t)
+			epoch := symbiotic.Epoch(250)
+
+			valset, _ := createValidatorSetWithCount(t, epoch, big.NewInt(670), 4)
+			valset.Status = symbiotic.HeaderDerived
+
+			valsetHeaderRequestID := common.BytesToHash(randomBytes(t, 32))
+			err := repo.SaveNextValsetData(t.Context(), entity.NextValsetData{
+				NextValidatorSet:     valset,
+				NextNetworkConfig:    randomNetworkConfig(),
+				PrevValidatorSet:     valset,
+				PrevNetworkConfig:    randomNetworkConfig(),
+				SignatureRequest:     nil,
+				ValidatorSetMetadata: symbiotic.ValidatorSetMetadata{RequestID: valsetHeaderRequestID, Epoch: epoch},
+			})
+			require.NoError(t, err)
+
+			storedValset, err := repo.GetValidatorSetByEpoch(t.Context(), epoch)
+			require.NoError(t, err)
+			require.Equal(t, symbiotic.HeaderDerived, storedValset.Status)
+
+			req := randomSignatureRequest(t, epoch)
+			msg := symbiotic.AggregationProof{
+				KeyTag:      req.KeyTag,
+				Epoch:       req.RequiredEpoch,
+				MessageHash: computeMessageHash(t, req.KeyTag, req.Message),
+				Proof:       randomBytes(t, 96),
+			}
+
+			require.NotEqual(t, valsetHeaderRequestID, msg.RequestID(), "repro needs a non-valset request ID")
+			require.NoError(t, repo.SaveSignatureRequest(t.Context(), msg.RequestID(), req))
+
+			processor, err := NewEntityProcessor(Config{
+				Repo:                     repo,
+				Aggregator:               createMockAggregator(t),
+				AggProofSignal:           createMockAggProofSignal(t),
+				SignatureProcessedSignal: createMockSignatureProcessedSignal(t),
+				Metrics:                  doNothingMetrics{},
+			})
+			require.NoError(t, err)
+
+			err = processor.ProcessAggregationProof(t.Context(), msg, false)
+			require.NoError(t, err)
+
+			storedValset, err = repo.GetValidatorSetByEpoch(t.Context(), epoch)
+			require.NoError(t, err)
+			require.Equal(t, symbiotic.HeaderDerived, storedValset.Status)
+
+			_, err = repo.GetAggregationProof(t.Context(), valsetHeaderRequestID)
+			require.ErrorIs(t, err, entity.ErrEntityNotFound)
+
+			_, err = repo.GetLatestAggregatedValsetHeader(t.Context())
+			require.ErrorIs(t, err, entity.ErrEntityNotFound)
+		})
+	}
+}
+
+func TestEntityProcessor_ProcessAggregationProof_UpdatesValidatorSetStatusForValsetProof(t *testing.T) {
+	t.Parallel()
+
+	for name, newRepo := range backends() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := newRepo(t)
+			epoch := symbiotic.Epoch(251)
+
+			valset, _ := createValidatorSetWithCount(t, epoch, big.NewInt(670), 4)
+			valset.Status = symbiotic.HeaderDerived
+
+			req := randomSignatureRequest(t, epoch)
+			msg := symbiotic.AggregationProof{
+				KeyTag:      req.KeyTag,
+				Epoch:       req.RequiredEpoch,
+				MessageHash: computeMessageHash(t, req.KeyTag, req.Message),
+				Proof:       randomBytes(t, 96),
+			}
+
+			err := repo.SaveNextValsetData(t.Context(), entity.NextValsetData{
+				NextValidatorSet:     valset,
+				NextNetworkConfig:    randomNetworkConfig(),
+				PrevValidatorSet:     valset,
+				PrevNetworkConfig:    randomNetworkConfig(),
+				SignatureRequest:     nil,
+				ValidatorSetMetadata: symbiotic.ValidatorSetMetadata{RequestID: msg.RequestID(), Epoch: epoch},
+			})
+			require.NoError(t, err)
+			require.NoError(t, repo.SaveSignatureRequest(t.Context(), msg.RequestID(), req))
+
+			processor, err := NewEntityProcessor(Config{
+				Repo:                     repo,
+				Aggregator:               createMockAggregator(t),
+				AggProofSignal:           createMockAggProofSignal(t),
+				SignatureProcessedSignal: createMockSignatureProcessedSignal(t),
+				Metrics:                  doNothingMetrics{},
+			})
+			require.NoError(t, err)
+
+			err = processor.ProcessAggregationProof(t.Context(), msg, false)
+			require.NoError(t, err)
+
+			storedValset, err := repo.GetValidatorSetByEpoch(t.Context(), epoch)
+			require.NoError(t, err)
+			require.Equal(t, symbiotic.HeaderAggregated, storedValset.Status)
+
+			expectedHeader, err := valset.GetHeader()
+			require.NoError(t, err)
+
+			latestAggregated, err := repo.GetLatestAggregatedValsetHeader(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, expectedHeader, latestAggregated)
+		})
+	}
+}
+
 func TestEntityProcessor_ProcessAggregationProof_FailsWhenAlreadyExists(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/entity-processor/entity_processor_test.go
+++ b/internal/usecase/entity-processor/entity_processor_test.go
@@ -2,6 +2,7 @@ package entity_processor
 
 import (
 	"crypto/rand"
+	stderrors "errors"
 	"math/big"
 	"testing"
 	"time"
@@ -648,27 +649,30 @@ func TestEntityProcessor_ProcessAggregationProof_DoesNotUpdateValidatorSetStatus
 			t.Parallel()
 
 			repo := newRepo(t)
-			epoch := symbiotic.Epoch(250)
+			signingEpoch := symbiotic.Epoch(250)
+			targetEpoch := symbiotic.Epoch(251)
 
-			valset, _ := createValidatorSetWithCount(t, epoch, big.NewInt(670), 4)
-			valset.Status = symbiotic.HeaderDerived
+			prevValset, _ := createValidatorSetWithCount(t, signingEpoch, big.NewInt(670), 4)
+			targetValset, _ := createValidatorSetWithCount(t, targetEpoch, big.NewInt(670), 4)
+			prevValset.Status = symbiotic.HeaderCommitted
+			targetValset.Status = symbiotic.HeaderDerived
 
 			valsetHeaderRequestID := common.BytesToHash(randomBytes(t, 32))
 			err := repo.SaveNextValsetData(t.Context(), entity.NextValsetData{
-				NextValidatorSet:     valset,
+				NextValidatorSet:     targetValset,
 				NextNetworkConfig:    randomNetworkConfig(),
-				PrevValidatorSet:     valset,
+				PrevValidatorSet:     prevValset,
 				PrevNetworkConfig:    randomNetworkConfig(),
 				SignatureRequest:     nil,
-				ValidatorSetMetadata: symbiotic.ValidatorSetMetadata{RequestID: valsetHeaderRequestID, Epoch: epoch},
+				ValidatorSetMetadata: symbiotic.ValidatorSetMetadata{RequestID: valsetHeaderRequestID, Epoch: targetEpoch},
 			})
 			require.NoError(t, err)
 
-			storedValset, err := repo.GetValidatorSetByEpoch(t.Context(), epoch)
+			storedValset, err := repo.GetValidatorSetByEpoch(t.Context(), targetEpoch)
 			require.NoError(t, err)
 			require.Equal(t, symbiotic.HeaderDerived, storedValset.Status)
 
-			req := randomSignatureRequest(t, epoch)
+			req := randomSignatureRequest(t, signingEpoch)
 			msg := symbiotic.AggregationProof{
 				KeyTag:      req.KeyTag,
 				Epoch:       req.RequiredEpoch,
@@ -691,7 +695,7 @@ func TestEntityProcessor_ProcessAggregationProof_DoesNotUpdateValidatorSetStatus
 			err = processor.ProcessAggregationProof(t.Context(), msg, false)
 			require.NoError(t, err)
 
-			storedValset, err = repo.GetValidatorSetByEpoch(t.Context(), epoch)
+			storedValset, err = repo.GetValidatorSetByEpoch(t.Context(), targetEpoch)
 			require.NoError(t, err)
 			require.Equal(t, symbiotic.HeaderDerived, storedValset.Status)
 
@@ -712,12 +716,15 @@ func TestEntityProcessor_ProcessAggregationProof_UpdatesValidatorSetStatusForVal
 			t.Parallel()
 
 			repo := newRepo(t)
-			epoch := symbiotic.Epoch(251)
+			signingEpoch := symbiotic.Epoch(250)
+			targetEpoch := symbiotic.Epoch(251)
 
-			valset, _ := createValidatorSetWithCount(t, epoch, big.NewInt(670), 4)
-			valset.Status = symbiotic.HeaderDerived
+			prevValset, _ := createValidatorSetWithCount(t, signingEpoch, big.NewInt(670), 4)
+			targetValset, _ := createValidatorSetWithCount(t, targetEpoch, big.NewInt(670), 4)
+			prevValset.Status = symbiotic.HeaderCommitted
+			targetValset.Status = symbiotic.HeaderDerived
 
-			req := randomSignatureRequest(t, epoch)
+			req := randomSignatureRequest(t, signingEpoch)
 			msg := symbiotic.AggregationProof{
 				KeyTag:      req.KeyTag,
 				Epoch:       req.RequiredEpoch,
@@ -726,12 +733,12 @@ func TestEntityProcessor_ProcessAggregationProof_UpdatesValidatorSetStatusForVal
 			}
 
 			err := repo.SaveNextValsetData(t.Context(), entity.NextValsetData{
-				NextValidatorSet:     valset,
+				NextValidatorSet:     targetValset,
 				NextNetworkConfig:    randomNetworkConfig(),
-				PrevValidatorSet:     valset,
+				PrevValidatorSet:     prevValset,
 				PrevNetworkConfig:    randomNetworkConfig(),
 				SignatureRequest:     nil,
-				ValidatorSetMetadata: symbiotic.ValidatorSetMetadata{RequestID: msg.RequestID(), Epoch: epoch},
+				ValidatorSetMetadata: symbiotic.ValidatorSetMetadata{RequestID: msg.RequestID(), Epoch: targetEpoch},
 			})
 			require.NoError(t, err)
 			require.NoError(t, repo.SaveSignatureRequest(t.Context(), msg.RequestID(), req))
@@ -748,11 +755,15 @@ func TestEntityProcessor_ProcessAggregationProof_UpdatesValidatorSetStatusForVal
 			err = processor.ProcessAggregationProof(t.Context(), msg, false)
 			require.NoError(t, err)
 
-			storedValset, err := repo.GetValidatorSetByEpoch(t.Context(), epoch)
+			storedPrevValset, err := repo.GetValidatorSetByEpoch(t.Context(), signingEpoch)
 			require.NoError(t, err)
-			require.Equal(t, symbiotic.HeaderAggregated, storedValset.Status)
+			require.Equal(t, symbiotic.HeaderCommitted, storedPrevValset.Status)
 
-			expectedHeader, err := valset.GetHeader()
+			storedTargetValset, err := repo.GetValidatorSetByEpoch(t.Context(), targetEpoch)
+			require.NoError(t, err)
+			require.Equal(t, symbiotic.HeaderAggregated, storedTargetValset.Status)
+
+			expectedHeader, err := targetValset.GetHeader()
 			require.NoError(t, err)
 
 			latestAggregated, err := repo.GetLatestAggregatedValsetHeader(t.Context())
@@ -760,6 +771,53 @@ func TestEntityProcessor_ProcessAggregationProof_UpdatesValidatorSetStatusForVal
 			require.Equal(t, expectedHeader, latestAggregated)
 		})
 	}
+}
+
+func TestEntityProcessor_ProcessAggregationProof_FailsBeforeSavingWhenValsetMetadataLookupFails(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	repo := mocks.NewMockRepository(ctrl)
+	aggregator := mocks.NewMockAggregator(ctrl)
+	aggProofSignal := mocks.NewMockAggProofSignal(ctrl)
+
+	msg := symbiotic.AggregationProof{
+		KeyTag:      symbiotic.KeyTag(15),
+		Epoch:       symbiotic.Epoch(250),
+		MessageHash: randomBytes(t, 32),
+		Proof:       randomBytes(t, 96),
+	}
+	repoErr := stderrors.New("metadata lookup failed")
+
+	repo.EXPECT().
+		GetAggregationProof(gomock.Any(), msg.RequestID()).
+		Return(symbiotic.AggregationProof{}, entity.ErrEntityNotFound)
+	repo.EXPECT().
+		GetValidatorSetMetadata(gomock.Any(), msg.Epoch+1).
+		Return(symbiotic.ValidatorSetMetadata{}, repoErr)
+	repo.EXPECT().
+		SaveProof(gomock.Any(), gomock.Any()).
+		Times(0)
+	repo.EXPECT().
+		UpdateValidatorSetStatus(gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+	aggProofSignal.EXPECT().
+		Emit(gomock.Any()).
+		Times(0)
+
+	processor, err := NewEntityProcessor(Config{
+		Repo:                     repo,
+		Aggregator:               aggregator,
+		AggProofSignal:           aggProofSignal,
+		SignatureProcessedSignal: createMockSignatureProcessedSignal(t),
+		Metrics:                  doNothingMetrics{},
+	})
+	require.NoError(t, err)
+
+	err = processor.ProcessAggregationProof(t.Context(), msg, true)
+	require.Error(t, err)
+	require.ErrorIs(t, err, repoErr)
+	require.Contains(t, err.Error(), "failed to get validator set metadata")
 }
 
 func TestEntityProcessor_ProcessAggregationProof_FailsWhenAlreadyExists(t *testing.T) {

--- a/internal/usecase/entity-processor/mocks/entity_processor.go
+++ b/internal/usecase/entity-processor/mocks/entity_processor.go
@@ -118,6 +118,21 @@ func (mr *MockRepositoryMockRecorder) GetValidatorSetByEpoch(ctx, epoch any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorSetByEpoch", reflect.TypeOf((*MockRepository)(nil).GetValidatorSetByEpoch), ctx, epoch)
 }
 
+// GetValidatorSetMetadata mocks base method.
+func (m *MockRepository) GetValidatorSetMetadata(ctx context.Context, epoch entity.Epoch) (entity.ValidatorSetMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetValidatorSetMetadata", ctx, epoch)
+	ret0, _ := ret[0].(entity.ValidatorSetMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetValidatorSetMetadata indicates an expected call of GetValidatorSetMetadata.
+func (mr *MockRepositoryMockRecorder) GetValidatorSetMetadata(ctx, epoch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorSetMetadata", reflect.TypeOf((*MockRepository)(nil).GetValidatorSetMetadata), ctx, epoch)
+}
+
 // SaveProof mocks base method.
 func (m *MockRepository) SaveProof(ctx context.Context, aggregationProof entity.AggregationProof) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### **User description**
closes #464


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Restrict valset aggregation status updates

- Match proofs against valset metadata

- Ignore unrelated epoch-bound aggregation proofs

- Add regression coverage for both paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  proof["Aggregation proof received"]
  save["Save aggregation proof"]
  meta["Load validator set metadata"]
  match["Request IDs match?"]
  update["Mark valset as HeaderAggregated"]
  done["Emit proof signal and finish"]

  proof -- "process" --> save
  save -- "then" --> meta
  meta -- "check" --> match
  match -- "yes" --> update
  match -- "no" --> done
  update -- "continue" --> done
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entity_processor.go</strong><dd><code>Guard valset aggregation status by request match</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/entity-processor/entity_processor.go

<ul><li>Add <code>GetValidatorSetMetadata</code> to repository contract<br> <li> Replace unconditional status update with guarded helper<br> <li> Update status only when <code>RequestID</code> matches metadata<br> <li> Ignore missing metadata instead of failing</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/465/files#diff-d6e4e8d9c7402c8c0a3278b15a2b5e287ebd6f0112290a8ce347cec1d3f96c97">+23/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entity_processor_test.go</strong><dd><code>Cover matching and non-matching proof behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/entity-processor/entity_processor_test.go

<ul><li>Add regression test for unrelated proofs<br> <li> Verify unrelated proofs keep valset unaggregated<br> <li> Add positive test for matching valset proofs<br> <li> Confirm latest aggregated header updates correctly</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/465/files#diff-4013ce53416c03e38e385a28bb1130b325a755da446dc2baa12106be6f5c0ff6">+122/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>entity_processor.go</strong><dd><code>Add repository mock for metadata lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/usecase/entity-processor/mocks/entity_processor.go

<ul><li>Generate mock support for <code>GetValidatorSetMetadata</code><br> <li> Enable tests and callers to expect metadata lookups</ul>


</details>


  </td>
  <td><a href="https://github.com/symbioticfi/relay/pull/465/files#diff-95edd0722be5cdb577526195172871c6f540150a72f728677a2538113b02d082">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

